### PR TITLE
Ac/phonemic distance

### DIFF
--- a/lib/features.py
+++ b/lib/features.py
@@ -1,3 +1,32 @@
+feature_weights = {
+    "syllabic": 1,
+    "consonantal": 1,
+    "approximant": 1,
+    "sonorant": 1,
+    "continuant": 1,
+    "delayed release": 1,
+    "tap": 1,
+    "trill": 1,
+    "nasal": 1,
+    "lateral": 1,
+    "voice": 1,
+    "spread gl": 1,
+    "constr gl": 1,
+    "labial": 1,
+    "round": 1,
+    "labiodental": 1,
+    "coronal": 1,
+    "anterior": 1,
+    "distributed": 1,
+    "strident": 1,
+    "dorsal": 1,
+    "high": 1,
+    "low": 1,
+    "front": 1,
+    "back": 1,
+    "tense": 1,
+}
+
 features = {
     "P": {
         "syllabic": "-",

--- a/lib/pronunciation.py
+++ b/lib/pronunciation.py
@@ -2,7 +2,7 @@ import cmudict
 from functools import reduce
 import re
 
-from lib.features import features
+from features import features
 
 
 # We store the cmudict as an object in memory so that we don't have to reload
@@ -63,3 +63,68 @@ def word_to_feature_matrix(word):
         feature_matrices.append(feature_matrix)
 
     return feature_matrices
+
+
+def word_phonemic_distance(source, target):
+    """
+    Takes two lists of phonemes, returns a distance score between two words
+    based on Levenshtein distance, using feature matrices for weights.
+    """
+    m = len(source)
+    n = len(target)
+
+    dist = [[0] * (m + 1) for i in range(n + 1)]
+
+    for i in range(n + 1):
+        for j in range(m + 1):
+            d_cost = float(del_cost(source[j - 1], j - 1))
+            i_cost = float(ins_cost(target[i - 1], i - 1))
+            s_cost = float(sub_cost(source[j - 1], target[i - 1], j - 1, i - 1))
+            i_cost = (
+                i_cost * 2 * (float(i) / n)
+            )  # sounds at the end are given more weight
+            d_cost = d_cost * 2 * (float(j) / m)
+            s_cost = s_cost * 2 * (float(j + i) / (m + n))
+            dist[i][j] = min(
+                dist[i - 1][j] + i_cost,
+                dist[i][j - 1] + d_cost,
+                dist[i - 1][j - 1] + s_cost,
+            )
+    return dist[i][j]
+
+
+def phonemic_distance(phon1, phon2):
+    """
+    Takes two phonemes and returns their distance 0-1
+    """
+    values = {"-": -1, "0": 0, "+": 1}
+    dist = 0
+    feats1 = features[phon1]
+    feats2 = features[phon2]
+    for f1 in feats1:
+        dist += abs(values[feats1[f1]] - values[feats2[f1]])
+    return dist / (float(len(list(feats1))))
+
+
+def ins_cost(phon, idx):
+    """
+    Returns cost of inserting a given phoneme and index
+    """
+    return 1
+
+
+def del_cost(phon, idx):
+    """
+    Returns cost of deleting a given phoneme and index
+    """
+    return 1
+
+
+def sub_cost(phon1, phon2, idx1, idx2):
+    """
+    Returns cost of replacing a given phoneme with another at given indices
+    """
+    if phon1 == phon2:
+        return 0
+    else:
+        return phonemic_distance(phon1, phon2)

--- a/lib/pronunciation.py
+++ b/lib/pronunciation.py
@@ -101,9 +101,11 @@ def phonemic_distance(phon1, phon2):
     dist = 0
     feats1 = features[phon1]
     feats2 = features[phon2]
+    total_weight = 0
     for f1 in feature_weights:
         dist += feature_weights[f1] * abs(values[feats1[f1]] - values[feats2[f1]])
-    return dist / (float(len(list(feats1))))
+        total_weight += feature_weights[f1]
+    return dist / (float(total_weight))
 
 
 def ins_cost(phon, idx):

--- a/lib/pronunciation.py
+++ b/lib/pronunciation.py
@@ -2,7 +2,7 @@ import cmudict
 from functools import reduce
 import re
 
-from features import features
+from features import features, feature_weights
 
 
 # We store the cmudict as an object in memory so that we don't have to reload
@@ -101,8 +101,8 @@ def phonemic_distance(phon1, phon2):
     dist = 0
     feats1 = features[phon1]
     feats2 = features[phon2]
-    for f1 in feats1:
-        dist += abs(values[feats1[f1]] - values[feats2[f1]])
+    for f1 in feature_weights:
+        dist += feature_weights[f1] * abs(values[feats1[f1]] - values[feats2[f1]])
     return dist / (float(len(list(feats1))))
 
 

--- a/tests/lib/test_features.py
+++ b/tests/lib/test_features.py
@@ -2,6 +2,7 @@ import cmudict
 import re
 
 from lib.features import features
+from lib.pronunciation import *
 
 
 def test_has_all_phonemes():
@@ -19,3 +20,16 @@ def test_has_all_phonemes():
     # Because they are all either diphthongs (which we map to monophthongs), or
     # for "ER" it's literally just the "R" sound.
     assert missing_phonemes == set(["AW", "AY", "ER", "EY", "OW", "OY"])
+
+
+def test_phonemic_levenshtein():
+    assert (
+        word_phonemic_distance(word_to_phonemes("reed")[0], word_to_phonemes("read")[1])
+        == 0
+    )
+
+
+def run_tests():
+    test_has_all_phonemes()
+    test_phonemic_levenshtein()
+    print("All tests passed!")


### PR DESCRIPTION
Added our phonemic distance functionality. Currently, this works on a basic level but the weights should be adjusted to better reflect the importance of certain features over others, as well as to better reflect the positional significance of where the change is happening within a word. For instance reed and seed rhyme, but would have a pretty similar phonemic distance to reed and reel- which is maybe an ok thing but definitely something to raise a discussion about. We can take a look at some cases and see what seems most important.

I also ran some tests locally and it seems to be functioning in the intended way.